### PR TITLE
Speed optimization

### DIFF
--- a/base58.go
+++ b/base58.go
@@ -1,33 +1,44 @@
 package base58
 
 import (
-	"bytes"
 	"fmt"
 	"math/big"
 )
 
 // An Encoding is a radix 58 encoding/decoding scheme.
 type Encoding struct {
-	alphabet []byte
+	alphabet  []byte
+	decodeMap [256]byte
+}
+
+func encoding(alphabet []byte) *Encoding {
+	enc := &Encoding{
+		alphabet: alphabet,
+	}
+	for i := range enc.decodeMap {
+		enc.decodeMap[i] = 0xFF
+	}
+	for i, b := range alphabet {
+		enc.decodeMap[b] = byte(i)
+	}
+	return enc
 }
 
 // FlickrEncoding is the encoding scheme used in Flickr's short URLs.
-var FlickrEncoding = &Encoding{
-	alphabet: []byte("123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ"),
-}
+var FlickrEncoding = encoding([]byte("123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ"))
 
 // RippleEncoding is the encoding scheme used Ripple addresses.
-var RippleEncoding = &Encoding{
-	alphabet: []byte("rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz"),
-}
+var RippleEncoding = encoding([]byte("rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz"))
 
 // BitcoinEncoding is the encoding scheme used Bitcoin addresses.
-var BitcoinEncoding = &Encoding{
-	alphabet: []byte("123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"),
-}
+var BitcoinEncoding = encoding([]byte("123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"))
 
 func (encoding *Encoding) index(c byte) int64 {
-	return int64(bytes.IndexByte(encoding.alphabet, c))
+	b := encoding.decodeMap[c]
+	if b == 0xFF {
+		return -1
+	}
+	return int64(b)
 }
 
 func (encoding *Encoding) at(idx int64) byte {

--- a/base58_test.go
+++ b/base58_test.go
@@ -83,3 +83,23 @@ func TestDecode(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkEncode(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		for _, testcase := range testcases {
+			for _, pair := range testcase.testpairs {
+				testcase.encoding.Encode([]byte(pair.decoded))
+			}
+		}
+	}
+}
+
+func BenchmarkDecode(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		for _, testcase := range testcases {
+			for _, pair := range testcase.testpairs {
+				testcase.encoding.Decode([]byte(pair.encoded))
+			}
+		}
+	}
+}


### PR DESCRIPTION
- Added simple benchmarks
- Small optimization for decode/introduce decodeMap
- Optimization for encode/reduce memory allocation

---

Before

```
$ go test -bench .
BenchmarkEncode-8          50000             31670 ns/op
BenchmarkDecode-8          50000             34311 ns/op
PASS
```

After   1a1d714

```
$ go test -bench .
BenchmarkEncode-8          50000             31852 ns/op
BenchmarkDecode-8          50000             31918 ns/op
PASS
```

After bb0d56b

```
$ go test -bench .
BenchmarkEncode-8         100000             22820 ns/op
BenchmarkDecode-8          50000             31596 ns/op
PASS
```
